### PR TITLE
fix: use ModelInfo for dynamic background detection (EDGEAI-1127)

### DIFF
--- a/src/camera.html
+++ b/src/camera.html
@@ -270,6 +270,15 @@
                             <span class="camera-controls__switch-slider"></span>
                         </label>
                     </div>
+                    <div class="camera-controls__suboptions" id="seg-options"
+                         data-testid="camera-options-segmentation">
+                        <label class="camera-controls__checkbox-label"
+                               id="seg-draw-bg-label" style="display:none">
+                            <input type="checkbox" id="seg-draw-background"
+                                   data-testid="camera-seg-draw-background">
+                            Draw Background
+                        </label>
+                    </div>
                 </div>
 
                 <!-- Bounding Boxes -->

--- a/src/camera.html
+++ b/src/camera.html
@@ -343,6 +343,12 @@
                                 Ground
                             </label>
                         </div>
+                        <label class="camera-controls__checkbox-label"
+                               id="lidar-draw-bg-label" style="display:none">
+                            <input type="checkbox" id="lidar-draw-background"
+                                   data-testid="camera-lidar-draw-background">
+                            Draw Background
+                        </label>
                     </div>
                 </div>
             </div>

--- a/src/js/ProjectedMask.js
+++ b/src/js/ProjectedMask.js
@@ -15,7 +15,7 @@ export default class ProjectedMask extends THREE.ShaderMaterial {
 
         if (!colors || colors.length == 0) {
             colors = [
-                new THREE.Color(0.0, 0.0, 0.0), // this color doesn't matter, it's always set to be alpha = 0
+                new THREE.Color(0.0, 0.0, 0.0),
                 new THREE.Color(0.25882353, 0.15294118, 0.13333333),
                 new THREE.Color(0., 1., 0.),
                 new THREE.Color(0.8, 0.76470588, 0.78039216),
@@ -38,7 +38,6 @@ export default class ProjectedMask extends THREE.ShaderMaterial {
 
         if (!alphas || alphas.length != colors.length) {
             alphas = Array(colors.length).fill(default_alpha);
-            alphas[0] = 0.0;
         }
 
         // zip colors and alphas together

--- a/src/js/camera.js
+++ b/src/js/camera.js
@@ -5,6 +5,7 @@ import ProjectedMaterial from './ProjectedMaterial.js'
 import h264Stream from './stream.js'
 import SmartVideoManager from './SmartVideoManager.js'
 import modelstream from './model.js'
+import ModelInfo from './modelInfo.js'
 import { mask_colors } from './utils.js'
 import { CdrReader } from './Cdr.js'
 import { parsePointCloud2, readField } from './pointcloud2.js'
@@ -22,6 +23,7 @@ let socketUrlLidar = '/api/rt/lidar/points/'
 let socketUrlLidarCluster = '/api/rt/lidar/clusters/'
 let socketUrlFusion = '/api/rt/fusion/lidar/'
 let socketUrlModel = '/api/rt/model/output/'
+let socketUrlModelInfo = '/api/rt/model/info/'
 let socketUrlTfStatic = '/api/rt/tf_static/'
 let socketUrlCameraInfo = '/api/rt/camera/info/'
 
@@ -39,6 +41,7 @@ let showLabels = true
 let showConfidence = true
 let lidarShowNoise = true
 let lidarShowGround = true
+let drawBackground = false
 
 // Overlay scene objects (for cleanup)
 let segMesh = null
@@ -73,6 +76,9 @@ const cameraUnavailable = document.getElementById('camera-unavailable')
 // Overlay controls
 const overlaySegToggle = document.getElementById('overlay-segmentation')
 const overlaySegSection = overlaySegToggle.closest('.camera-controls__section')
+const segOptions = document.getElementById('seg-options')
+const segDrawBgCheckbox = document.getElementById('seg-draw-background')
+const segDrawBgLabel = document.getElementById('seg-draw-bg-label')
 
 const overlayBoxToggle = document.getElementById('overlay-box2d')
 const overlayBoxSection = overlayBoxToggle.closest('.camera-controls__section')
@@ -403,13 +409,15 @@ function renderSegmentation() {
                 bboxesArr[base + 3] = 1
             }
         } else {
-            // Semantic color from mask_colors
+            // Semantic color from mask_colors — all classes are valid unless
+            // ModelInfo identifies them as background
+            const isBg = ModelInfo.isBackground(i)
             const cls = Math.min(i, mask_colors.length - 1)
             const mc = mask_colors[cls]
             colorsArr[base] = mc.r
             colorsArr[base + 1] = mc.g
             colorsArr[base + 2] = mc.b
-            colorsArr[base + 3] = i === 0 ? 0.0 : 0.7  // class 0 is background → transparent
+            colorsArr[base + 3] = (isBg && !drawBackground) ? 0.0 : 0.7
 
             // Full-frame for semantic
             bboxesArr[base] = 0
@@ -809,7 +817,7 @@ function renderLidarOverlay() {
             color = clusterColor(readField(parsed, i, hasClusterId))
         } else if (lidarColorMode === 'vision_class' && hasVisionClass) {
             const cls = readField(parsed, i, hasVisionClass)
-            if (cls <= 0) continue
+            if (ModelInfo.isBackground(cls) && !drawBackground) continue
             color = cls < mask_colors.length
                 ? { r: mask_colors[cls].r, g: mask_colors[cls].g, b: mask_colors[cls].b }
                 : { r: 0.5, g: 0.5, b: 0.5 }
@@ -1157,8 +1165,13 @@ function wireToggle(checkbox, section, options, onToggle) {
 overlaySegToggle.addEventListener('change', () => {
     segEnabled = overlaySegToggle.checked
     overlaySegSection.setAttribute('data-active', segEnabled)
+    segOptions.setAttribute('data-visible', segEnabled)
     if (segEnabled) startSegmentation()
     else stopSegmentation()
+})
+
+segDrawBgCheckbox.addEventListener('change', () => {
+    drawBackground = segDrawBgCheckbox.checked
 })
 
 wireToggle(overlayBoxToggle, overlayBoxSection, boxOptions, (on) => {
@@ -1220,6 +1233,14 @@ function resetTimeout() {
 
 // Show unavailable initially until first frame arrives
 cameraUnavailable.style.display = 'flex'
+
+// ---------------------------------------------------------------------------
+// ModelInfo — show/hide "Draw Background" toggle when background is detected
+// ---------------------------------------------------------------------------
+ModelInfo.onChange(() => {
+    segDrawBgLabel.style.display = ModelInfo.hasBackground ? '' : 'none'
+})
+ModelInfo.connect(socketUrlModelInfo)
 
 // ---------------------------------------------------------------------------
 // Boot

--- a/src/js/camera.js
+++ b/src/js/camera.js
@@ -93,6 +93,8 @@ const lidarColorSelect = document.getElementById('lidar-color-mode')
 const lidarClusterFilters = document.getElementById('lidar-cluster-filters')
 const lidarNoiseCheckbox = document.getElementById('lidar-show-noise')
 const lidarGroundCheckbox = document.getElementById('lidar-show-ground')
+const lidarDrawBgCheckbox = document.getElementById('lidar-draw-background')
+const lidarDrawBgLabel = document.getElementById('lidar-draw-bg-label')
 
 // ---------------------------------------------------------------------------
 // THREE.js Scene
@@ -1172,7 +1174,9 @@ overlaySegToggle.addEventListener('change', () => {
 
 segDrawBgCheckbox.addEventListener('change', () => {
     drawBackground = segDrawBgCheckbox.checked
+    lidarDrawBgCheckbox.checked = drawBackground
 })
+
 
 wireToggle(overlayBoxToggle, overlayBoxSection, boxOptions, (on) => {
     boxEnabled = on
@@ -1189,6 +1193,7 @@ wireToggle(overlayLidarToggle, overlayLidarSection, lidarOptions, (on) => {
 lidarColorSelect.addEventListener('change', () => {
     lidarColorMode = lidarColorSelect.value
     lidarClusterFilters.setAttribute('data-visible', lidarColorMode === 'cluster')
+    updateLidarBgVisibility()
     if (lidarEnabled) connectEnrichedSocket()
 })
 
@@ -1196,6 +1201,15 @@ boxLabelsCheckbox.addEventListener('change', () => { showLabels = boxLabelsCheck
 boxConfidenceCheckbox.addEventListener('change', () => { showConfidence = boxConfidenceCheckbox.checked })
 lidarNoiseCheckbox.addEventListener('change', () => { lidarShowNoise = lidarNoiseCheckbox.checked })
 lidarGroundCheckbox.addEventListener('change', () => { lidarShowGround = lidarGroundCheckbox.checked })
+lidarDrawBgCheckbox.addEventListener('change', () => {
+    drawBackground = lidarDrawBgCheckbox.checked
+    segDrawBgCheckbox.checked = drawBackground
+})
+
+function updateLidarBgVisibility() {
+    lidarDrawBgLabel.style.display =
+        (lidarColorMode === 'vision_class' && ModelInfo.hasBackground) ? '' : 'none'
+}
 
 // ---------------------------------------------------------------------------
 // Animation Loop
@@ -1239,6 +1253,7 @@ cameraUnavailable.style.display = 'flex'
 // ---------------------------------------------------------------------------
 ModelInfo.onChange(() => {
     segDrawBgLabel.style.display = ModelInfo.hasBackground ? '' : 'none'
+    updateLidarBgVisibility()
 })
 ModelInfo.connect(socketUrlModelInfo)
 

--- a/src/js/lidar.js
+++ b/src/js/lidar.js
@@ -4,6 +4,7 @@
 import * as THREE from './three.js'
 import { OrbitControls } from './OrbitControls.js'
 import { PCDLoader } from './PCDLoader.js'
+import ModelInfo from './modelInfo.js'
 import { mask_colors } from './utils.js'
 import { parsePointCloud2, extractFieldArray } from './pointcloud2.js'
 
@@ -31,6 +32,7 @@ let fusionWarningTimer = null
 let cachedIsDark = true   // cached theme state — updated on themechange
 let showNoise = true
 let showGround = true
+let drawBackground = false
 let lastPositions = null  // Float32Array of original XYZ positions
 
 // ---------------------------------------------------------------------------
@@ -43,6 +45,8 @@ const lidarUnavailable = document.getElementById('lidar-unavailable')
 const clusterFilters = document.getElementById('cluster-filters')
 const showNoiseCheckbox = document.getElementById('show-noise')
 const showGroundCheckbox = document.getElementById('show-ground')
+const bgFilter = document.getElementById('bg-filter')
+const showBgCheckbox = document.getElementById('show-background')
 let unavailableTimer = null
 
 // ---------------------------------------------------------------------------
@@ -303,7 +307,7 @@ function applyColorMode(group) {
                 const cls = (hasData && i < lastParsedPoints.length)
                     ? lastParsedPoints[i] : 0
 
-                if (cls <= 0) {
+                if (ModelInfo.isBackground(cls) && !drawBackground) {
                     colors[i * 3] = gr
                     colors[i * 3 + 1] = gr
                     colors[i * 3 + 2] = gr
@@ -410,6 +414,7 @@ function showFusionWarning() {
 colorModeSelect.addEventListener('change', () => {
     currentColorMode = colorModeSelect.value
     updateClusterFiltersVisibility()
+    updateBgFilterVisibility()
     switchTopic()
 
     // When switching to a mode that needs a different topic, wait for the first
@@ -439,6 +444,16 @@ showGroundCheckbox.addEventListener('change', () => {
         filterClusterPoints(pointsGroup)
     }
 })
+
+showBgCheckbox.addEventListener('change', () => {
+    drawBackground = showBgCheckbox.checked
+    if (pointsGroup) applyColorMode(pointsGroup)
+})
+
+function updateBgFilterVisibility() {
+    bgFilter.style.display = (currentColorMode === 'vision_class' && ModelInfo.hasBackground)
+        ? 'flex' : 'none'
+}
 
 // ---------------------------------------------------------------------------
 // Part C: WebSocket & Point Cloud Rendering
@@ -624,6 +639,15 @@ document.addEventListener('themechange', (e) => {
         })
     }
 })
+
+// ---------------------------------------------------------------------------
+// ModelInfo — show/hide "Draw Background" toggle when background is detected
+// ---------------------------------------------------------------------------
+ModelInfo.onChange(() => {
+    updateBgFilterVisibility()
+    if (pointsGroup) applyColorMode(pointsGroup)
+})
+ModelInfo.connect('/api/rt/model/info/')
 
 // ---------------------------------------------------------------------------
 // Initialisation

--- a/src/js/modelInfo.js
+++ b/src/js/modelInfo.js
@@ -1,52 +1,144 @@
 // Copyright (C) 2025 Au-Zone Technologies Inc. All Rights Reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-import * as THREE from './three.js';
-import { CdrReader } from './Cdr.js';
+import { CdrReader } from './Cdr.js'
 
-export default async function modelInfo(socketUrl, onFirstMessage) {
-    const modelShape = {}
-    const socket = new WebSocket(socketUrl);
-    socket.binaryType = "arraybuffer";
-    socket.onopen = function (event) {
-        console.log('WebSocket connection opened to ' + socketUrl);
-    };
-    socket.onmessage = (event) => {
-        const arrayBuffer = event.data;
-        const dataView = new DataView(arrayBuffer);
-        const reader = new CdrReader(dataView);
-        let mask;
-        try {
-            const header_stamp_sec = reader.uint32() // Read header.stamp.sec
-            const header_stamp_nsec = reader.uint32() // Read header.stamp.nsec
-            const header_frame_id = reader.string()
+const RECONNECT_MIN_MS = 1000
+const RECONNECT_MAX_MS = 8000
+const BG_PATTERN = /^(background|bg)$/i
 
-            const input_shape = reader.uint32Array()
-            const input_type = reader.uint8()
+/**
+ * ModelInfo singleton — subscribes to /api/rt/model/info/ and exposes:
+ *   - labels: string[] of model class labels
+ *   - numClasses: number of drawable classes (labels.length)
+ *   - isBackground(classId): whether a class should be treated as background
+ *   - hasBackground: whether any background class was detected
+ *   - onChange(callback): register a listener for when model info updates
+ */
+const ModelInfo = {
+    labels: [],
+    numClasses: 0,
+    hasBackground: false,
 
-            const output_shape = reader.uint32Array()
-            const output_type = reader.uint8()
+    _listeners: [],
+    _socket: null,
+    _stopped: false,
+    _reconnectDelay: RECONNECT_MIN_MS,
+    _reconnectTimer: null,
+    _bgIndices: new Set(),
 
-            const labels = reader.stringArray()
+    /**
+     * Returns true if the given class index should be treated as background.
+     * Background is detected in two ways:
+     *   1. Label matches "background" or "bg" (case-insensitive)
+     *   2. Class index >= numClasses (beyond the known label set)
+     */
+    isBackground(classId) {
+        if (this.numClasses > 0 && classId >= this.numClasses) return true
+        return this._bgIndices.has(classId)
+    },
 
-            const model_type = reader.string()
-            const model_format = reader.string()
-            const model_name = reader.string()
-        } catch (error) {
-            console.error("Failed to deserialize model info:", error);
-            return;
+    /**
+     * Register a callback invoked when model info is received or updated.
+     * Callback receives this ModelInfo object.
+     */
+    onChange(callback) {
+        this._listeners.push(callback)
+    },
+
+    /**
+     * Open the WebSocket connection to the model info topic.
+     * Safe to call multiple times — will not open duplicate connections.
+     */
+    connect(socketUrl) {
+        if (this._socket) return
+        this._stopped = false
+        this._doConnect(socketUrl)
+    },
+
+    /**
+     * Close the connection and stop reconnection.
+     */
+    close() {
+        this._stopped = true
+        clearTimeout(this._reconnectTimer)
+        if (this._socket) {
+            this._socket.onclose = null
+            this._socket.close()
+            this._socket = null
         }
-        onFirstMessage(output_shape)
-        socket.close()
-    };
-    socket.onerror = function (error) {
-        console.error(`WebSocket ${socketUrl} error: ${error}`);
-    };
+    },
 
-    socket.onclose = function (event) {
-        console.log(`WebSocket ${socketUrl} connection closed`);
-    };
+    _doConnect(url) {
+        if (this._stopped) return
 
-    return;
+        const ws = new WebSocket(url)
+        ws.binaryType = 'arraybuffer'
+
+        ws.onopen = () => {
+            this._reconnectDelay = RECONNECT_MIN_MS
+        }
+
+        ws.onmessage = (event) => {
+            try {
+                this._parse(event.data)
+            } catch (error) {
+                console.error('Failed to deserialize model info:', error)
+            }
+        }
+
+        ws.onerror = (e) => {
+            console.warn('ModelInfo WebSocket error:', e)
+        }
+
+        ws.onclose = () => {
+            this._socket = null
+            if (this._stopped) return
+            this._reconnectTimer = setTimeout(() => this._doConnect(url), this._reconnectDelay)
+            this._reconnectDelay = Math.min(this._reconnectDelay * 2, RECONNECT_MAX_MS)
+        }
+
+        this._socket = ws
+    },
+
+    _parse(arrayBuffer) {
+        const dataView = new DataView(arrayBuffer)
+        const reader = new CdrReader(dataView)
+
+        // Header
+        reader.uint32() // stamp.sec
+        reader.uint32() // stamp.nanosec
+        reader.string() // frame_id
+
+        const input_shape = reader.uint32Array()
+        const input_type = reader.uint8()
+        const output_shape = reader.uint32Array()
+        const output_type = reader.uint8()
+
+        const labels = reader.stringArray()
+
+        const model_type = reader.string()
+        const model_format = reader.string()
+        const model_name = reader.string()
+
+        // Detect background labels
+        const bgIndices = new Set()
+        for (let i = 0; i < labels.length; i++) {
+            if (BG_PATTERN.test(labels[i].trim())) {
+                bgIndices.add(i)
+            }
+        }
+
+        this.labels = labels
+        this.numClasses = labels.length
+        this._bgIndices = bgIndices
+        this.hasBackground = bgIndices.size > 0
+
+        // Notify listeners
+        for (const cb of this._listeners) {
+            try { cb(this) } catch (e) { console.error('ModelInfo listener error:', e) }
+        }
+    },
 }
 
+export default ModelInfo

--- a/src/js/modelInfo.js
+++ b/src/js/modelInfo.js
@@ -110,18 +110,18 @@ const ModelInfo = {
         reader.uint32() // stamp.nanosec
         reader.string() // frame_id
 
-        const input_shape = reader.uint32Array()
-        const input_type = reader.uint8()
-        const output_shape = reader.uint32Array()
-        const output_type = reader.uint8()
+        this.inputShape = reader.uint32Array()
+        this.inputType = reader.uint8()
+        this.outputShape = reader.uint32Array()
+        this.outputType = reader.uint8()
 
         const labels = reader.stringArray()
 
-        const model_type = reader.string()
-        const model_format = reader.string()
-        const model_name = reader.string()
+        this.modelType = reader.string()
+        this.modelFormat = reader.string()
+        this.modelName = reader.string()
 
-        // Detect background labels
+        // Detect background labels (explicit match on label text)
         const bgIndices = new Set()
         for (let i = 0; i < labels.length; i++) {
             if (BG_PATTERN.test(labels[i].trim())) {
@@ -129,10 +129,17 @@ const ModelInfo = {
             }
         }
 
+        // Detect implicit background: output_shape's class dimension may
+        // exceed the label count when the model includes an unlabelled
+        // background class (typically the last output channel)
+        const outputClasses = this.outputShape.length > 0
+            ? this.outputShape[this.outputShape.length - 1] : 0
+        const hasImplicitBg = outputClasses > labels.length
+
         this.labels = labels
         this.numClasses = labels.length
         this._bgIndices = bgIndices
-        this.hasBackground = bgIndices.size > 0
+        this.hasBackground = bgIndices.size > 0 || hasImplicitBg
 
         // Notify listeners
         for (const cb of this._listeners) {

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -80,8 +80,9 @@ export function color_points_class(points, field, scene, rendered_points, height
     points.forEach((point) => {
         let point_rad = 0.075
         let color = new THREE.Color(0xFFFFFF)
-        if (point[field] > 0) {
-            color = mask_colors[point[field]]
+        const cls = point[field]
+        if (cls >= 0 && cls < mask_colors.length) {
+            color = mask_colors[cls]
             point_rad = 0.15
         }
 
@@ -130,7 +131,7 @@ function combined_classes(points) {
 }
 
 export const mask_colors = [
-    new THREE.Color(0.0, 0.0, 0.0), // this color doesn't matter, it's always set to be alpha = 0
+    new THREE.Color(0.0, 0.0, 0.0),
     new THREE.Color(0., 1., 0.),
     new THREE.Color(0.50980392, 0.50980392, 0.72941176),
     new THREE.Color(0.00784314, 0.18823529, 0.29411765),

--- a/src/lidar.html
+++ b/src/lidar.html
@@ -93,8 +93,30 @@
             white-space: nowrap;
         }
 
-        #cluster-filters input[type="checkbox"] {
+        #cluster-filters input[type="checkbox"],
+        #bg-filter input[type="checkbox"] {
             accent-color: var(--brand-gold);
+        }
+
+        #bg-filter {
+            display: none;
+            align-items: center;
+            gap: 6px;
+            padding: 6px 12px;
+            border-radius: 6px;
+            border: 1px solid var(--color-border);
+            background-color: var(--color-bg-surface);
+            color: var(--color-text-primary);
+            font-size: 13px;
+            box-shadow: 0 2px 4px var(--color-shadow);
+        }
+
+        #bg-filter label {
+            display: flex;
+            align-items: center;
+            gap: 4px;
+            cursor: pointer;
+            white-space: nowrap;
         }
 
         #fusion-warning {
@@ -148,6 +170,9 @@
                 <div id="cluster-filters" data-testid="lidar-cluster-filters">
                     <label><input type="checkbox" id="show-noise" data-testid="lidar-show-noise" checked> Noise</label>
                     <label><input type="checkbox" id="show-ground" data-testid="lidar-show-ground" checked> Ground</label>
+                </div>
+                <div id="bg-filter" style="display:none" data-testid="lidar-bg-filter">
+                    <label><input type="checkbox" id="show-background" data-testid="lidar-show-background"> Draw Background</label>
                 </div>
             </div>
             <div id="fusion-warning" data-testid="lidar-fusion-warning">Fusion data unavailable — showing distance colours</div>


### PR DESCRIPTION
## Summary

- Replace hardcoded class 0 = background with dynamic detection via `/api/rt/model/info/` topic
- Background determined by labels beyond `len(labels)` or matching "background"/"bg" (case-insensitive)
- Add "Draw Background" toggle (hidden by default, shown when background detected) on camera and LiDAR pages
- All class IDs render as valid when no ModelInfo is available (graceful degradation)

Fixes [EDGEAI-1127](https://au-zone.atlassian.net/browse/EDGEAI-1127)

## Test plan

- [ ] Semantic segmentation with model that has no background label — all classes including class 0 render
- [ ] Semantic segmentation with model whose last label is "background" — class hidden, toggle appears
- [ ] Enable "Draw Background" — hidden class renders with assigned color
- [ ] LiDAR Vision Class mode — class 0 no longer grayed out or skipped
- [ ] LiDAR Vision Class with background label — points grayed, toggle appears
- [ ] Camera LiDAR overlay Vision Class — same behaviour as LiDAR page
- [ ] No model info topic available — all classes render, toggle hidden
- [ ] Bounding box labels align 1:1 with mask class colors (no off-by-one)

[EDGEAI-1127]: https://au-zone.atlassian.net/browse/EDGEAI-1127?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ